### PR TITLE
Fix mess_warden in Mess Module

### DIFF
--- a/FusionIIIT/applications/central_mess/views.py
+++ b/FusionIIIT/applications/central_mess/views.py
@@ -378,17 +378,17 @@ def mess(request):
 
             elif f.feedback_type == 'Others' and mess_opt.mess_option == 'mess2':
                 count8 += 1
-            context = {
-                 'info': extrainfo,
-                 'menu': y,
-                 'meeting': meeting,
-                 'minutes': minutes,
-                 'count1': count1,
-                 'count2': count2, 'count3': count3, 'feed': feed,
-                 'count4': count4, 'form': form, 'count5': count5,
-                 'count6': count6, 'count7': count7, 'count8': count8, 'desig': desig
-            }
-            return render(request, 'messModule/mess.html', context)
+        context = {
+             'info': extrainfo,
+             'menu': y,
+             'meeting': meeting,
+             'minutes': minutes,
+             'count1': count1,
+             'count2': count2, 'count3': count3, 'feed': feed,
+             'count4': count4, 'form': form, 'count5': count5,
+             'count6': count6, 'count7': count7, 'count8': count8, 'desig': desig
+        }
+        return render(request, 'messModule/mess.html', context)
 
 
 @login_required


### PR DESCRIPTION
On opening "Mess Module" from "mess_warden" account, it shows error.

![2019-10-02](https://user-images.githubusercontent.com/39924567/66102441-07e64300-e5d0-11e9-83c8-6123d8411e60.png)

On looking the central_mess.views code, I found that the Context and return statements were written under the for loop. Removed the indentation from the context and return statement.

Working fine now.

![2019-10-03](https://user-images.githubusercontent.com/39924567/66103159-7c21e600-e5d2-11e9-89ea-86933567a745.png)
